### PR TITLE
분석 탁자 추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,47 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "1.19.x" ]
+  pull_request:
+    branches: [ "1.19.x" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 리포지토리 checkout
+      uses: actions/checkout@v3
+
+    - name: JDK 17 다운로드
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Gradle 캐시
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+        
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: build
+      timeout-minutes: 25

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,9 +124,8 @@ minecraft.run {
 
         all {
             lazyToken("minecraft_classpath") {
-                val joined = configurations.getByName("library").copyRecursive().resolve()
+                return@lazyToken configurations.getByName("library").copyRecursive().resolve()
                     .joinToString(File.pathSeparator) { it.absolutePath }
-                return@lazyToken joined
             }
         }
     }

--- a/src/generated/resources/assets/soluna/lang/en_us.json
+++ b/src/generated/resources/assets/soluna/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+  "block.soluna.analysis_table": "Analysis Table",
+  "itemGroup.soluna": "Soluna",
+  "key.categories.soluna": "Soluna"
+}

--- a/src/generated/resources/assets/soluna/lang/ko_kr.json
+++ b/src/generated/resources/assets/soluna/lang/ko_kr.json
@@ -1,0 +1,5 @@
+{
+  "block.soluna.analysis_table": "분석 탁자",
+  "itemGroup.soluna": "Soluna",
+  "key.categories.soluna": "Soluna"
+}

--- a/src/generated/resources/data/soluna/advancements/recipes/soluna/analysis_table.json
+++ b/src/generated/resources/data/soluna/advancements/recipes/soluna/analysis_table.json
@@ -1,0 +1,47 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_enchanted_book": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:enchanted_book"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_lectern": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:lectern"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "soluna:analysis_table"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_lectern",
+      "has_enchanted_book",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "soluna:analysis_table"
+    ]
+  }
+}

--- a/src/generated/resources/data/soluna/recipes/analysis_table.json
+++ b/src/generated/resources/data/soluna/recipes/analysis_table.json
@@ -1,0 +1,25 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "e": {
+      "item": "minecraft:leather"
+    },
+    "f": {
+      "item": "minecraft:feather"
+    },
+    "i": {
+      "item": "minecraft:ink_sac"
+    },
+    "l": {
+      "item": "minecraft:lectern"
+    }
+  },
+  "pattern": [
+    "e  ",
+    "li ",
+    "f  "
+  ],
+  "result": {
+    "item": "soluna:analysis_table"
+  }
+}

--- a/src/main/kotlin/com/hkmod/soluna/Soluna.kt
+++ b/src/main/kotlin/com/hkmod/soluna/Soluna.kt
@@ -19,7 +19,7 @@ const val MODID = "soluna"
 
 @Mod(MODID)
 object Soluna {
-    private val LOGGER: Logger = LogManager.getLogger()
+    val LOGGER: Logger = LogManager.getLogger()
 
     init {
         LOGGER.log(Level.INFO, "$MODID has started!")

--- a/src/main/kotlin/com/hkmod/soluna/Soluna.kt
+++ b/src/main/kotlin/com/hkmod/soluna/Soluna.kt
@@ -5,9 +5,7 @@ import com.hkmod.soluna.client.renderer.registerRenderers
 import com.hkmod.soluna.common.blocks.SolunaBlocks
 import com.hkmod.soluna.common.blocks.entity.SolunaBlockEntities
 import com.hkmod.soluna.common.items.SolunaItems
-import net.minecraft.world.item.CreativeModeTab
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.item.Items
+import com.hkmod.soluna.datagen.datagen
 import net.minecraftforge.fml.common.Mod
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
@@ -27,17 +25,11 @@ object Soluna {
         SolunaItems.registerItems(MOD_BUS)
         SolunaBlocks.registerBlocks(MOD_BUS)
         SolunaBlockEntities.registerBEs(MOD_BUS)
+        MOD_BUS.addListener(::datagen)
 
         if (DIST.isClient) {
             MOD_BUS.addListener(KeyBindings::registerKeybindings)
             MOD_BUS.addListener(::registerRenderers)
         }
     }
-}
-
-object SolunaTab : CreativeModeTab(-1, MODID) {
-    override fun makeIcon(): ItemStack {
-        return ItemStack(Items.DIAMOND)
-    }
-
 }

--- a/src/main/kotlin/com/hkmod/soluna/client/renderer/AnalysisTableRenderer.kt
+++ b/src/main/kotlin/com/hkmod/soluna/client/renderer/AnalysisTableRenderer.kt
@@ -4,25 +4,18 @@ import com.hkmod.soluna.common.blocks.AnalysisTable
 import com.hkmod.soluna.common.blocks.entity.AnalysisTableEntity
 import com.mojang.blaze3d.vertex.PoseStack
 import com.mojang.math.Vector3f
-import net.minecraft.client.Minecraft
 import net.minecraft.client.model.BookModel
 import net.minecraft.client.model.geom.ModelLayers
 import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.RenderType
-import net.minecraft.client.renderer.block.model.ItemTransforms
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider
 import net.minecraft.client.renderer.blockentity.EnchantTableRenderer
 import net.minecraft.client.renderer.entity.ItemRenderer
-import net.minecraft.core.Direction
 import net.minecraft.resources.ResourceLocation
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.item.Items
 
 class AnalysisTableRenderer(context: BlockEntityRendererProvider.Context): BlockEntityRenderer<AnalysisTableEntity> {
     private val bookModel: BookModel = BookModel(context.bakeLayer(ModelLayers.BOOK))
-    private val itemRenderer: ItemRenderer by lazy { Minecraft.getInstance().itemRenderer }
-    private val feather = ItemStack(Items.FEATHER)
     override fun render(
         blockEntity: AnalysisTableEntity,
         partialTick: Float,
@@ -39,7 +32,7 @@ class AnalysisTableRenderer(context: BlockEntityRendererProvider.Context): Block
             poseStack.mulPose(Vector3f.YP.rotationDegrees(-yDegree))
             poseStack.mulPose(Vector3f.ZP.rotationDegrees(67.5f))
             poseStack.translate(0.0, -0.125, 0.0)
-            bookModel.setupAnim(0.0F, 0.0F, 0.9F, 1.2F)
+            bookModel.setupAnim(0.0F, 0.05F, 0.95F, 1.2F)
             val vertexConsumer = EnchantTableRenderer.BOOK_LOCATION.buffer(bufferSource) { location: ResourceLocation ->
                 RenderType.entitySolid(location)
             }
@@ -49,29 +42,6 @@ class AnalysisTableRenderer(context: BlockEntityRendererProvider.Context): Block
             bookModel.render(poseStack, vertexConsumer, packedLight, packedOverlay, 1.0f, 1.0f, 1.0f, 1.0f)
 
             bookModel.render(poseStack, foilConsumer, packedLight, packedOverlay, 1.0f, 1.0f, 1.0f, 1.0f)
-            poseStack.popPose()
-
-            poseStack.pushPose()
-            when(blockState.getValue(AnalysisTable.FACING)) {
-                Direction.NORTH -> {}
-                Direction.SOUTH -> {
-                    poseStack.translate(1.0, 0.0, 1.0)
-                }
-                Direction.WEST -> {
-                    poseStack.translate(0.0, 0.0, 1.0)
-                }
-                Direction.EAST -> {
-                    poseStack.translate(1.0, 0.0, 0.0)
-                }
-                else -> {}
-            }
-            poseStack.mulPose(Vector3f.YP.rotationDegrees(-yDegree))
-            poseStack.translate(-0.2, 1.08, 0.3)
-            poseStack.mulPose(Vector3f.YP.rotationDegrees(90F))
-            poseStack.mulPose(Vector3f.XP.rotationDegrees(-67.5F))
-            poseStack.mulPose(Vector3f.ZP.rotationDegrees(45F))
-            poseStack.scale(1.2F, 1.2F, 1.2F)
-            itemRenderer.renderStatic(feather, ItemTransforms.TransformType.GROUND, packedLight, packedOverlay, poseStack, bufferSource, 0)
             poseStack.popPose()
         }
     }

--- a/src/main/kotlin/com/hkmod/soluna/client/renderer/AnalysisTableRenderer.kt
+++ b/src/main/kotlin/com/hkmod/soluna/client/renderer/AnalysisTableRenderer.kt
@@ -1,16 +1,50 @@
 package com.hkmod.soluna.client.renderer
 
+import com.hkmod.soluna.common.blocks.AnalysisTable
 import com.hkmod.soluna.common.blocks.entity.AnalysisTableEntity
 import com.mojang.blaze3d.vertex.PoseStack
+import com.mojang.math.Vector3f
+import net.minecraft.client.model.BookModel
+import net.minecraft.client.model.geom.ModelLayers
 import net.minecraft.client.renderer.MultiBufferSource
+import net.minecraft.client.renderer.RenderType
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider
+import net.minecraft.client.renderer.blockentity.EnchantTableRenderer
+import net.minecraft.client.renderer.entity.ItemRenderer
+import net.minecraft.resources.ResourceLocation
 
-fun renderAnalysisTable(
-    blockEntity: AnalysisTableEntity,
-    partialTick: Float,
-    poseStack: PoseStack,
-    bufferSource: MultiBufferSource,
-    packedLight: Int,
-    packedOverlay: Int
-) {
+class AnalysisTableRenderer(context: BlockEntityRendererProvider.Context): BlockEntityRenderer<AnalysisTableEntity> {
+    private val bookModel: BookModel = BookModel(context.bakeLayer(ModelLayers.BOOK))
+    override fun render(
+        blockEntity: AnalysisTableEntity,
+        partialTick: Float,
+        poseStack: PoseStack,
+        bufferSource: MultiBufferSource,
+        packedLight: Int,
+        packedOverlay: Int
+    ) {
+        val blockState = blockEntity.blockState
+        if (blockState.getValue(AnalysisTable.HAS_BOOK)) {
+            poseStack.pushPose()
+            poseStack.translate(0.5, 1.1, 0.5)
+            val yDegree = blockState.getValue(AnalysisTable.FACING).clockWise.toYRot()
+            poseStack.mulPose(Vector3f.YP.rotationDegrees(-yDegree))
+            poseStack.mulPose(Vector3f.ZP.rotationDegrees(67.5f))
+            poseStack.translate(0.0, -0.125, 0.0)
+            bookModel.setupAnim(0.0f, 0.1f, 0.9f, 1.2f)
+            val vertexConsumer = EnchantTableRenderer.BOOK_LOCATION.buffer(bufferSource) { location: ResourceLocation ->
+                RenderType.entitySolid(location)
+            }
+
+            val foilConsumer = ItemRenderer.getFoilBufferDirect(bufferSource, RenderType.glintTranslucent(), false, true)
+
+            bookModel.render(poseStack, vertexConsumer, packedLight, packedOverlay, 1.0f, 1.0f, 1.0f, 1.0f)
+            poseStack.pushPose()
+            bookModel.render(poseStack, foilConsumer, packedLight, packedOverlay, 1.0f, 1.0f, 1.0f, 1.0f)
+            poseStack.popPose()
+            poseStack.popPose()
+        }
+    }
 
 }

--- a/src/main/kotlin/com/hkmod/soluna/client/renderer/AnalysisTableRenderer.kt
+++ b/src/main/kotlin/com/hkmod/soluna/client/renderer/AnalysisTableRenderer.kt
@@ -4,18 +4,25 @@ import com.hkmod.soluna.common.blocks.AnalysisTable
 import com.hkmod.soluna.common.blocks.entity.AnalysisTableEntity
 import com.mojang.blaze3d.vertex.PoseStack
 import com.mojang.math.Vector3f
+import net.minecraft.client.Minecraft
 import net.minecraft.client.model.BookModel
 import net.minecraft.client.model.geom.ModelLayers
 import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.RenderType
+import net.minecraft.client.renderer.block.model.ItemTransforms
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider
 import net.minecraft.client.renderer.blockentity.EnchantTableRenderer
 import net.minecraft.client.renderer.entity.ItemRenderer
+import net.minecraft.core.Direction
 import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 
 class AnalysisTableRenderer(context: BlockEntityRendererProvider.Context): BlockEntityRenderer<AnalysisTableEntity> {
     private val bookModel: BookModel = BookModel(context.bakeLayer(ModelLayers.BOOK))
+    private val itemRenderer: ItemRenderer by lazy { Minecraft.getInstance().itemRenderer }
+    private val feather = ItemStack(Items.FEATHER)
     override fun render(
         blockEntity: AnalysisTableEntity,
         partialTick: Float,
@@ -32,7 +39,7 @@ class AnalysisTableRenderer(context: BlockEntityRendererProvider.Context): Block
             poseStack.mulPose(Vector3f.YP.rotationDegrees(-yDegree))
             poseStack.mulPose(Vector3f.ZP.rotationDegrees(67.5f))
             poseStack.translate(0.0, -0.125, 0.0)
-            bookModel.setupAnim(0.0f, 0.1f, 0.9f, 1.2f)
+            bookModel.setupAnim(0.0F, 0.0F, 0.9F, 1.2F)
             val vertexConsumer = EnchantTableRenderer.BOOK_LOCATION.buffer(bufferSource) { location: ResourceLocation ->
                 RenderType.entitySolid(location)
             }
@@ -40,9 +47,31 @@ class AnalysisTableRenderer(context: BlockEntityRendererProvider.Context): Block
             val foilConsumer = ItemRenderer.getFoilBufferDirect(bufferSource, RenderType.glintTranslucent(), false, true)
 
             bookModel.render(poseStack, vertexConsumer, packedLight, packedOverlay, 1.0f, 1.0f, 1.0f, 1.0f)
-            poseStack.pushPose()
+
             bookModel.render(poseStack, foilConsumer, packedLight, packedOverlay, 1.0f, 1.0f, 1.0f, 1.0f)
             poseStack.popPose()
+
+            poseStack.pushPose()
+            when(blockState.getValue(AnalysisTable.FACING)) {
+                Direction.NORTH -> {}
+                Direction.SOUTH -> {
+                    poseStack.translate(1.0, 0.0, 1.0)
+                }
+                Direction.WEST -> {
+                    poseStack.translate(0.0, 0.0, 1.0)
+                }
+                Direction.EAST -> {
+                    poseStack.translate(1.0, 0.0, 0.0)
+                }
+                else -> {}
+            }
+            poseStack.mulPose(Vector3f.YP.rotationDegrees(-yDegree))
+            poseStack.translate(-0.2, 1.08, 0.3)
+            poseStack.mulPose(Vector3f.YP.rotationDegrees(90F))
+            poseStack.mulPose(Vector3f.XP.rotationDegrees(-67.5F))
+            poseStack.mulPose(Vector3f.ZP.rotationDegrees(45F))
+            poseStack.scale(1.2F, 1.2F, 1.2F)
+            itemRenderer.renderStatic(feather, ItemTransforms.TransformType.GROUND, packedLight, packedOverlay, poseStack, bufferSource, 0)
             poseStack.popPose()
         }
     }

--- a/src/main/kotlin/com/hkmod/soluna/client/renderer/Register.kt
+++ b/src/main/kotlin/com/hkmod/soluna/client/renderer/Register.kt
@@ -1,12 +1,10 @@
 package com.hkmod.soluna.client.renderer
 
 import com.hkmod.soluna.common.blocks.entity.SolunaBlockEntities.ANALYSIS_TABLE_ENTITY
-import net.minecraft.client.renderer.blockentity.BlockEntityRenderer
 import net.minecraftforge.client.event.EntityRenderersEvent
 
 fun registerRenderers(event: EntityRenderersEvent.RegisterRenderers) {
     event.registerBlockEntityRenderer(ANALYSIS_TABLE_ENTITY) {
-        BlockEntityRenderer { pBlockEntity, pPartialTick, pPoseStack, pBufferSource, pPackedLight, pPackedOverlay ->
-            renderAnalysisTable(pBlockEntity, pPartialTick, pPoseStack, pBufferSource, pPackedLight, pPackedOverlay) }
+        AnalysisTableRenderer(it)
     }
 }

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
@@ -1,8 +1,8 @@
 package com.hkmod.soluna.common.blocks
 
-import com.hkmod.soluna.Soluna.LOGGER
 import com.hkmod.soluna.common.blocks.entity.AnalysisTableEntity
 import com.hkmod.soluna.common.blocks.entity.SolunaBlockEntities.ANALYSIS_TABLE_ENTITY
+import com.hkmod.soluna.common.util.devException
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.sounds.SoundEvents
@@ -28,7 +28,6 @@ import net.minecraft.world.phys.BlockHitResult
 import net.minecraft.world.phys.shapes.CollisionContext
 import net.minecraft.world.phys.shapes.Shapes
 import net.minecraft.world.phys.shapes.VoxelShape
-import net.minecraftforge.fml.loading.FMLEnvironment
 
 @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
 class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
@@ -74,13 +73,11 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
 
         val blockEntity = level.getBlockEntity(blockPos)
         if (blockEntity !is AnalysisTableEntity) {
-            if (!FMLEnvironment.production) {
-                LOGGER.warn("There is block entity that's not AnalysisTableEntity at $blockPos!!")
-                Thread.dumpStack()
-            }
+            devException("There is block entity that's not AnalysisTableEntity at $blockPos!!")
             return false
         }
-        if (!blockEntity.setBook(book.split(1))) return false
+
+        blockEntity.book = book.split(1)
 
         level.setBlock(blockPos, state.setValue(HAS_BOOK, true), 3)
         level.playSound(null, blockPos, SoundEvents.BOOK_PUT, SoundSource.BLOCKS, 1F, 1F)
@@ -106,7 +103,7 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
         var hasBook = false
         if (!level.isClientSide && player != null && player.canUseGameMasterBlocks()) {
             val tag = BlockItem.getBlockEntityData(itemStack)
-            if (tag != null && tag.contains("Book")) {
+            if (tag != null && tag.contains("book")) {
                 hasBook = true
             }
         }
@@ -152,15 +149,12 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
         val blockEntity = level.getBlockEntity(pos)
 
         if (blockEntity !is AnalysisTableEntity) {
-            if (!FMLEnvironment.production) {
-                LOGGER.warn("There is block entity that's not AnalysisTableEntity at $pos!!")
-                Thread.dumpStack()
-            }
+            devException("There is block entity that's not AnalysisTableEntity at $pos!!")
             return
         }
 
-        val book = blockEntity.getBook().copy()
-        blockEntity.setBook(ItemStack.EMPTY)
+        val book = blockEntity.book.copy()
+        blockEntity.book = ItemStack.EMPTY
         player.setItemInHand(pullHand, book)
         level.setBlock(pos, state.setValue(HAS_BOOK, false), 3)
     }
@@ -172,19 +166,15 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
         val blockEntity = level.getBlockEntity(pos)
         if (blockEntity is AnalysisTableEntity) {
             val direction = state.getValue(FACING)
-            val itemStack = blockEntity.getBook().copy()
+            val itemStack = blockEntity.book.copy()
             val x = 0.25F * direction.stepX
             val z = 0.25F * direction.stepZ
             val itemEntity = ItemEntity(level, pos.x + 0.5 + x, pos.y + 1.0, pos.z + 0.5 + z, itemStack)
             itemEntity.setDefaultPickUpDelay()
             level.addFreshEntity(itemEntity)
-            blockEntity.setBook(ItemStack.EMPTY)
-            level.setBlock(pos, state.setValue(HAS_BOOK, false), 3)
+            blockEntity.book = ItemStack.EMPTY
         } else {
-            if (!FMLEnvironment.production) {
-                LOGGER.warn("There is block entity that's not AnalysisTableEntity at $pos!!")
-                Thread.dumpStack()
-            }
+            devException("There is block entity that's not AnalysisTableEntity at $pos!!")
             return
         }
 

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
@@ -1,13 +1,199 @@
 package com.hkmod.soluna.common.blocks
 
+import com.hkmod.soluna.Soluna.LOGGER
 import com.hkmod.soluna.common.blocks.entity.AnalysisTableEntity
 import com.hkmod.soluna.common.blocks.entity.SolunaBlockEntities.ANALYSIS_TABLE_ENTITY
 import net.minecraft.core.BlockPos
+import net.minecraft.core.Direction
+import net.minecraft.sounds.SoundEvents
+import net.minecraft.sounds.SoundSource
+import net.minecraft.world.InteractionHand
+import net.minecraft.world.InteractionResult
+import net.minecraft.world.entity.item.ItemEntity
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.BlockItem
+import net.minecraft.world.item.EnchantedBookItem
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.context.BlockPlaceContext
+import net.minecraft.world.level.BlockGetter
+import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.EntityBlock
+import net.minecraft.world.level.block.HorizontalDirectionalBlock
+import net.minecraft.world.level.block.Mirror
+import net.minecraft.world.level.block.RenderShape
+import net.minecraft.world.level.block.Rotation
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.level.block.state.StateDefinition
+import net.minecraft.world.level.block.state.properties.BlockStateProperties
+import net.minecraft.world.level.gameevent.GameEvent
+import net.minecraft.world.phys.BlockHitResult
+import net.minecraft.world.phys.shapes.CollisionContext
+import net.minecraft.world.phys.shapes.Shapes
+import net.minecraft.world.phys.shapes.VoxelShape
+import net.minecraftforge.fml.loading.FMLEnvironment
 
+@Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
 class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
-    override fun newBlockEntity(pPos: BlockPos, pState: BlockState) = AnalysisTableEntity(ANALYSIS_TABLE_ENTITY, pPos, pState)
+    companion object {
+        val FACING = HorizontalDirectionalBlock.FACING
+        val HAS_BOOK = BlockStateProperties.HAS_BOOK
+
+        val SHAPE_BASE = box(0.0, 0.0, 0.0, 16.0, 2.0, 16.0)
+        val SHAPE_POST = box(4.0, 2.0, 4.0, 12.0, 14.0, 12.0)
+        val SHAPE_COMMON = Shapes.or(SHAPE_BASE, SHAPE_POST)
+        val SHAPE_TOP_PLATE = box(0.0, 15.0, 0.0, 16.0, 15.0, 16.0)
+        val SHAPE_COLLISION = Shapes.or(SHAPE_COMMON, SHAPE_TOP_PLATE)
+        val SHAPE_WEST = Shapes.or(box(1.0, 10.0, 0.0, 5.333333, 14.0, 16.0), box(5.333333, 12.0, 0.0, 9.666667, 16.0, 16.0), box(9.666667, 14.0, 0.0, 14.0, 18.0, 16.0), SHAPE_COMMON)
+        val SHAPE_NORTH = Shapes.or(box(0.0, 10.0, 1.0, 16.0, 14.0, 5.333333), box(0.0, 12.0, 5.333333, 16.0, 16.0, 9.666667), box(0.0, 14.0, 9.666667, 16.0, 18.0, 14.0), SHAPE_COMMON)
+        val SHAPE_EAST = Shapes.or(box(10.666667, 10.0, 0.0, 15.0, 14.0, 16.0), box(6.333333, 12.0, 0.0, 10.666667, 16.0, 16.0), box(2.0, 14.0, 0.0, 6.333333, 18.0, 16.0), SHAPE_COMMON)
+        val SHAPE_SOUTH = Shapes.or(box(0.0, 10.0, 10.666667, 16.0, 14.0, 15.0), box(0.0, 12.0, 6.333333, 16.0, 16.0, 10.666667), box(0.0, 14.0, 2.0, 16.0, 18.0, 6.333333), SHAPE_COMMON)
+    }
+
+    init {
+        registerDefaultState(stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(HAS_BOOK, false))
+    }
+
+    override fun use(state: BlockState, level: Level, pos: BlockPos, player: Player, hand: InteractionHand, hit: BlockHitResult): InteractionResult {
+        val itemStack = player.getItemInHand(hand)
+
+        return if (!state.getValue(HAS_BOOK)) {
+            if (placeBook(level, pos, state, itemStack, player)) {
+                InteractionResult.CONSUME
+            } else {
+                InteractionResult.PASS
+            }
+        } else {
+            pullBook(level, pos, state, player, hand)
+            InteractionResult.SUCCESS
+        }
+    }
+
+    private fun placeBook(level: Level, blockPos: BlockPos, state: BlockState, book: ItemStack, player: Player?): Boolean {
+        if (state.getValue(HAS_BOOK)) return false
+        if (book.isEmpty) return false
+        if (book.item !is EnchantedBookItem) return false
+        if (level.isClientSide) return true
+
+        val blockEntity = level.getBlockEntity(blockPos)
+        if (blockEntity !is AnalysisTableEntity) {
+            if (!FMLEnvironment.production) {
+                LOGGER.warn("There is block entity that's not AnalysisTableEntity at $blockPos!!")
+                Thread.dumpStack()
+            }
+            return false
+        }
+        if (!blockEntity.setBook(book.split(1))) return false
+
+        level.setBlock(blockPos, state.setValue(HAS_BOOK, true), 3)
+        level.playSound(null, blockPos, SoundEvents.BOOK_PUT, SoundSource.BLOCKS, 1F, 1F)
+        level.playSound(null, blockPos, SoundEvents.ENCHANTMENT_TABLE_USE, SoundSource.BLOCKS, 0.7F, 1.2F)
+        level.gameEvent(player, GameEvent.BLOCK_CHANGE, blockPos)
+        return true
+    }
+
+    /**
+     * The type of render function called. MODEL for mixed tesr and static model, MODELBLOCK_ANIMATED for TESR-only,
+     * LIQUID for vanilla liquids, INVISIBLE to skip all rendering
+     */
+    override fun getRenderShape(state: BlockState) = RenderShape.MODEL
+
+    override fun getOcclusionShape(state: BlockState, level: BlockGetter, pos: BlockPos): VoxelShape = SHAPE_COMMON
+
+    override fun useShapeForLightOcclusion(state: BlockState) = true
+
+    override fun getStateForPlacement(context: BlockPlaceContext): BlockState {
+        val level = context.level
+        val itemStack = context.itemInHand
+        val player = context.player
+        var hasBook = false
+        if (!level.isClientSide && player != null && player.canUseGameMasterBlocks()) {
+            val tag = BlockItem.getBlockEntityData(itemStack)
+            if (tag != null && tag.contains("Book")) {
+                hasBook = true
+            }
+        }
+        return defaultBlockState().setValue(FACING, context.horizontalDirection.opposite).setValue(HAS_BOOK, hasBook)
+    }
+
+    override fun getShape(pState: BlockState, pLevel: BlockGetter, pPos: BlockPos, pContext: CollisionContext): VoxelShape {
+        return when (pState.getValue(FACING) as Direction) {
+            Direction.NORTH -> SHAPE_NORTH
+            Direction.SOUTH -> SHAPE_SOUTH
+            Direction.EAST -> SHAPE_EAST
+            Direction.WEST -> SHAPE_WEST
+            else -> SHAPE_COMMON
+        }
+    }
+
+    override fun rotate(state: BlockState, rotation: Rotation): BlockState {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)))
+    }
+
+    override fun mirror(state: BlockState, mirror: Mirror): BlockState {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)))
+    }
+
+    override fun createBlockStateDefinition(builder: StateDefinition.Builder<Block?, BlockState?>) {
+        builder.add(FACING, HAS_BOOK)
+    }
+
+    override fun onRemove(pState: BlockState, pLevel: Level, pPos: BlockPos, pNewState: BlockState, pIsMoving: Boolean) {
+        if (!pState.`is`(pNewState.block)) {
+            if (pState.getValue(HAS_BOOK)) {
+                popBook(pState, pLevel, pPos)
+            }
+            super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving)
+        }
+    }
+
+    private fun pullBook(level: Level, pos: BlockPos, state: BlockState, player: Player, pullHand: InteractionHand) {
+        if (level.isClientSide) return
+        if (!state.getValue(HAS_BOOK)) return
+        if (!player.getItemInHand(pullHand).isEmpty) return
+
+        val blockEntity = level.getBlockEntity(pos)
+
+        if (blockEntity !is AnalysisTableEntity) {
+            if (!FMLEnvironment.production) {
+                LOGGER.warn("There is block entity that's not AnalysisTableEntity at $pos!!")
+                Thread.dumpStack()
+            }
+            return
+        }
+
+        val book = blockEntity.getBook().copy()
+        blockEntity.setBook(ItemStack.EMPTY)
+        player.setItemInHand(pullHand, book)
+        level.setBlock(pos, state.setValue(HAS_BOOK, false), 3)
+    }
+
+    private fun popBook(state: BlockState, level: Level, pos: BlockPos) {
+        if (level.isClientSide) return
+        if (!state.getValue(HAS_BOOK)) return
+
+        val blockEntity = level.getBlockEntity(pos)
+        if (blockEntity is AnalysisTableEntity) {
+            val direction = state.getValue(FACING)
+            val itemStack = blockEntity.getBook().copy()
+            val x = 0.25F * direction.stepX
+            val z = 0.25F * direction.stepZ
+            val itemEntity = ItemEntity(level, pos.x + 0.5 + x, pos.y + 1.0, pos.z + 0.5 + z, itemStack)
+            itemEntity.setDefaultPickUpDelay()
+            level.addFreshEntity(itemEntity)
+            blockEntity.setBook(ItemStack.EMPTY)
+            level.setBlock(pos, state.setValue(HAS_BOOK, false), 3)
+        } else {
+            if (!FMLEnvironment.production) {
+                LOGGER.warn("There is block entity that's not AnalysisTableEntity at $pos!!")
+                Thread.dumpStack()
+            }
+            return
+        }
+
+    }
+
+    override fun getCollisionShape(state: BlockState, pLevel: BlockGetter, pPos: BlockPos, pContext: CollisionContext): VoxelShape = SHAPE_COLLISION
+    override fun newBlockEntity(pPos: BlockPos, state: BlockState) = AnalysisTableEntity(ANALYSIS_TABLE_ENTITY, pPos, state)
 
 }

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
@@ -17,15 +17,12 @@ import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.context.BlockPlaceContext
 import net.minecraft.world.level.BlockGetter
 import net.minecraft.world.level.Level
-import net.minecraft.world.level.block.Block
-import net.minecraft.world.level.block.EntityBlock
-import net.minecraft.world.level.block.HorizontalDirectionalBlock
-import net.minecraft.world.level.block.Mirror
-import net.minecraft.world.level.block.RenderShape
-import net.minecraft.world.level.block.Rotation
+import net.minecraft.world.level.block.*
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.block.state.StateDefinition
 import net.minecraft.world.level.block.state.properties.BlockStateProperties
+import net.minecraft.world.level.block.state.properties.BooleanProperty
+import net.minecraft.world.level.block.state.properties.DirectionProperty
 import net.minecraft.world.level.gameevent.GameEvent
 import net.minecraft.world.phys.BlockHitResult
 import net.minecraft.world.phys.shapes.CollisionContext
@@ -36,18 +33,18 @@ import net.minecraftforge.fml.loading.FMLEnvironment
 @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
 class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
     companion object {
-        val FACING = HorizontalDirectionalBlock.FACING
-        val HAS_BOOK = BlockStateProperties.HAS_BOOK
+        val FACING: DirectionProperty = HorizontalDirectionalBlock.FACING
+        val HAS_BOOK: BooleanProperty = BlockStateProperties.HAS_BOOK
 
-        val SHAPE_BASE = box(0.0, 0.0, 0.0, 16.0, 2.0, 16.0)
-        val SHAPE_POST = box(4.0, 2.0, 4.0, 12.0, 14.0, 12.0)
-        val SHAPE_COMMON = Shapes.or(SHAPE_BASE, SHAPE_POST)
-        val SHAPE_TOP_PLATE = box(0.0, 15.0, 0.0, 16.0, 15.0, 16.0)
-        val SHAPE_COLLISION = Shapes.or(SHAPE_COMMON, SHAPE_TOP_PLATE)
-        val SHAPE_WEST = Shapes.or(box(1.0, 10.0, 0.0, 5.333333, 14.0, 16.0), box(5.333333, 12.0, 0.0, 9.666667, 16.0, 16.0), box(9.666667, 14.0, 0.0, 14.0, 18.0, 16.0), SHAPE_COMMON)
-        val SHAPE_NORTH = Shapes.or(box(0.0, 10.0, 1.0, 16.0, 14.0, 5.333333), box(0.0, 12.0, 5.333333, 16.0, 16.0, 9.666667), box(0.0, 14.0, 9.666667, 16.0, 18.0, 14.0), SHAPE_COMMON)
-        val SHAPE_EAST = Shapes.or(box(10.666667, 10.0, 0.0, 15.0, 14.0, 16.0), box(6.333333, 12.0, 0.0, 10.666667, 16.0, 16.0), box(2.0, 14.0, 0.0, 6.333333, 18.0, 16.0), SHAPE_COMMON)
-        val SHAPE_SOUTH = Shapes.or(box(0.0, 10.0, 10.666667, 16.0, 14.0, 15.0), box(0.0, 12.0, 6.333333, 16.0, 16.0, 10.666667), box(0.0, 14.0, 2.0, 16.0, 18.0, 6.333333), SHAPE_COMMON)
+        private val SHAPE_BASE: VoxelShape = box(0.0, 0.0, 0.0, 16.0, 2.0, 16.0)
+        private val SHAPE_POST: VoxelShape = box(4.0, 2.0, 4.0, 12.0, 14.0, 12.0)
+        val SHAPE_COMMON: VoxelShape = Shapes.or(SHAPE_BASE, SHAPE_POST)
+        private val SHAPE_TOP_PLATE: VoxelShape = box(0.0, 15.0, 0.0, 16.0, 15.0, 16.0)
+        val SHAPE_COLLISION: VoxelShape = Shapes.or(SHAPE_COMMON, SHAPE_TOP_PLATE)
+        val SHAPE_WEST: VoxelShape = Shapes.or(box(1.0, 10.0, 0.0, 5.333333, 14.0, 16.0), box(5.333333, 12.0, 0.0, 9.666667, 16.0, 16.0), box(9.666667, 14.0, 0.0, 14.0, 18.0, 16.0), SHAPE_COMMON)
+        val SHAPE_NORTH: VoxelShape = Shapes.or(box(0.0, 10.0, 1.0, 16.0, 14.0, 5.333333), box(0.0, 12.0, 5.333333, 16.0, 16.0, 9.666667), box(0.0, 14.0, 9.666667, 16.0, 18.0, 14.0), SHAPE_COMMON)
+        val SHAPE_EAST: VoxelShape = Shapes.or(box(10.666667, 10.0, 0.0, 15.0, 14.0, 16.0), box(6.333333, 12.0, 0.0, 10.666667, 16.0, 16.0), box(2.0, 14.0, 0.0, 6.333333, 18.0, 16.0), SHAPE_COMMON)
+        val SHAPE_SOUTH: VoxelShape = Shapes.or(box(0.0, 10.0, 10.666667, 16.0, 14.0, 15.0), box(0.0, 12.0, 6.333333, 16.0, 16.0, 10.666667), box(0.0, 14.0, 2.0, 16.0, 18.0, 6.333333), SHAPE_COMMON)
     }
 
     init {
@@ -93,7 +90,7 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
     }
 
     /**
-     * The type of render function called. MODEL for mixed tesr and static model, MODELBLOCK_ANIMATED for TESR-only,
+     * The type of render function called. [RenderShape.MODEL] for mixed tesr and static model, [RenderShape.ENTITYBLOCK_ANIMATED] for TESR-only,
      * LIQUID for vanilla liquids, INVISIBLE to skip all rendering
      */
     override fun getRenderShape(state: BlockState) = RenderShape.MODEL

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
@@ -79,7 +79,6 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
 
         blockEntity.book = book.split(1)
 
-        level.setBlock(blockPos, state.setValue(HAS_BOOK, true), 3)
         level.playSound(null, blockPos, SoundEvents.BOOK_PUT, SoundSource.BLOCKS, 1F, 1F)
         level.playSound(null, blockPos, SoundEvents.ENCHANTMENT_TABLE_USE, SoundSource.BLOCKS, 0.7F, 1.2F)
         level.gameEvent(player, GameEvent.BLOCK_CHANGE, blockPos)
@@ -154,7 +153,6 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
         val book = blockEntity.book.copy()
         blockEntity.book = ItemStack.EMPTY
         player.setItemInHand(pullHand, book)
-        level.setBlock(pos, state.setValue(HAS_BOOK, false), 3)
     }
 
     private fun popBook(state: BlockState, level: Level, pos: BlockPos) {
@@ -170,6 +168,7 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
             val itemEntity = ItemEntity(level, pos.x + 0.5 + x, pos.y + 1.0, pos.z + 0.5 + z, itemStack)
             itemEntity.setDefaultPickUpDelay()
             level.addFreshEntity(itemEntity)
+            blockEntity.book = ItemStack.EMPTY
         } else {
             devException("There is block entity that's not AnalysisTableEntity at $pos!!")
             return

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/AnalysisTable.kt
@@ -132,12 +132,10 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
         builder.add(FACING, HAS_BOOK)
     }
 
-    override fun onRemove(pState: BlockState, pLevel: Level, pPos: BlockPos, pNewState: BlockState, pIsMoving: Boolean) {
-        if (!pState.`is`(pNewState.block)) {
-            if (pState.getValue(HAS_BOOK)) {
-                popBook(pState, pLevel, pPos)
-            }
-            super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving)
+    override fun onRemove(state: BlockState, level: Level, pos: BlockPos, newState: BlockState, isMoving: Boolean) {
+        if (!state.`is`(newState.block)) {
+            popBook(state, level, pos)
+            super.onRemove(state, level, pos, newState, isMoving)
         }
     }
 
@@ -172,7 +170,6 @@ class AnalysisTable(properties: Properties) : Block(properties), EntityBlock {
             val itemEntity = ItemEntity(level, pos.x + 0.5 + x, pos.y + 1.0, pos.z + 0.5 + z, itemStack)
             itemEntity.setDefaultPickUpDelay()
             level.addFreshEntity(itemEntity)
-            blockEntity.book = ItemStack.EMPTY
         } else {
             devException("There is block entity that's not AnalysisTableEntity at $pos!!")
             return

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/SolunaBlocks.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/SolunaBlocks.kt
@@ -2,7 +2,6 @@ package com.hkmod.soluna.common.blocks
 
 import com.hkmod.soluna.MODID
 import com.hkmod.soluna.SolunaTab
-import com.hkmod.soluna.common.util.resource
 import net.minecraft.world.item.BlockItem
 import net.minecraft.world.item.Item
 import net.minecraft.world.level.block.Block
@@ -22,11 +21,13 @@ object SolunaBlocks {
         AnalysisTable(BlockBehaviour.Properties.copy(Blocks.LECTERN))
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun registerBlockAndItem(name: String, supplier: () -> Block): ReadOnlyProperty<Any?, Block> {
+        val futureBlock = BLOCKS.registerObject(name, supplier)
         BLOCK_ITEMS.register(name) {
-            BlockItem(ForgeRegistries.BLOCKS.getValue(name.resource)!!, Item.Properties().tab(SolunaTab))
+            BlockItem((futureBlock as () -> Block)(), Item.Properties().tab(SolunaTab))
         }
-        return BLOCKS.registerObject(name, supplier)
+        return futureBlock
     }
     fun registerBlocks(bus: IEventBus) {
         BLOCKS.register(bus)

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/SolunaBlocks.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/SolunaBlocks.kt
@@ -1,7 +1,7 @@
 package com.hkmod.soluna.common.blocks
 
 import com.hkmod.soluna.MODID
-import com.hkmod.soluna.SolunaTab
+import com.hkmod.soluna.common.items.SolunaTab
 import net.minecraft.world.item.BlockItem
 import net.minecraft.world.item.Item
 import net.minecraft.world.level.block.Block

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
@@ -27,7 +27,7 @@ class AnalysisTableEntity(type: BlockEntityType<AnalysisTableEntity>, pos: Block
         override fun onContentsChanged(slot: Int) {
             super.onContentsChanged(slot)
             setChanged()
-            if (level?.isClientSide == false) {
+            if (!isRemoved && level?.isClientSide == false) {
                 level!!.setBlockAndUpdate(pos, state.setValue(AnalysisTable.HAS_BOOK, !stacks[0].isEmpty))
             }
         }

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
@@ -1,9 +1,9 @@
 package com.hkmod.soluna.common.blocks.entity
 
 import com.hkmod.soluna.common.blocks.AnalysisTable
+import com.hkmod.soluna.common.blocks.SolunaBlocks
 import com.hkmod.soluna.common.util.devException
 import net.minecraft.core.BlockPos
-import net.minecraft.core.Direction
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.Connection
 import net.minecraft.network.protocol.Packet
@@ -14,53 +14,26 @@ import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
-import net.minecraftforge.common.capabilities.Capability
-import net.minecraftforge.common.capabilities.CapabilityManager
-import net.minecraftforge.common.capabilities.CapabilityToken
-import net.minecraftforge.common.util.LazyOptional
-import net.minecraftforge.items.IItemHandler
-import net.minecraftforge.items.ItemStackHandler
 
 class AnalysisTableEntity(type: BlockEntityType<AnalysisTableEntity>, pos: BlockPos, state: BlockState) :
     BlockEntity(type, pos, state) {
-    private val inventory = object : ItemStackHandler(1) {
-        override fun onContentsChanged(slot: Int) {
-            super.onContentsChanged(slot)
-            setChanged()
-            if (!isRemoved && level?.isClientSide == false) {
-                level!!.setBlockAndUpdate(pos, state.setValue(AnalysisTable.HAS_BOOK, !stacks[0].isEmpty))
-            }
-        }
-
-        override fun isItemValid(slot: Int, stack: ItemStack): Boolean {
-            return super.isItemValid(slot, stack) && (stack.item is EnchantedBookItem || stack.isEmpty)
-        }
-    }
-    private val inventoryLazy = LazyOptional.of { inventory }
-
-    var book: ItemStack
+    var book: ItemStack = ItemStack.EMPTY
         set(value) {
-            if (!inventory.isItemValid(0, value)) {
+            if (!isItemValid(value)) {
                 devException("Please don't put non-enchanted book item into the table, please :)")
             } else {
-                inventory.setStackInSlot(0, value)
+                field = value
+                if (level?.isClientSide == false) {
+                    val blockState = level!!.getBlockState(blockPos)
+                    if (blockState.`is`(SolunaBlocks.ANALYSIS_TABLE)) {
+                        level!!.setBlockAndUpdate(blockPos, blockState.setValue(AnalysisTable.HAS_BOOK, !value.isEmpty))
+                    }
+                }
             }
         }
-        get() = inventory.getStackInSlot(0)
 
-    companion object {
-        val INVENTORY_CAP: Capability<IItemHandler> = CapabilityManager.get(object : CapabilityToken<IItemHandler>() {})
-    }
-
-    override fun <T : Any?> getCapability(cap: Capability<T>, side: Direction?): LazyOptional<T> {
-        if (cap == INVENTORY_CAP) return inventoryLazy.cast()
-
-        return super.getCapability(cap, side)
-    }
-
-    override fun invalidateCaps() {
-        super.invalidateCaps()
-        inventoryLazy.invalidate()
+    fun isItemValid(itemStack: ItemStack): Boolean {
+        return itemStack.item is EnchantedBookItem || itemStack.isEmpty
     }
 
     override fun saveAdditional(tag: CompoundTag) {

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
@@ -1,6 +1,7 @@
 package com.hkmod.soluna.common.blocks.entity
 
-import com.hkmod.soluna.Soluna.LOGGER
+import com.hkmod.soluna.common.blocks.AnalysisTable
+import com.hkmod.soluna.common.util.devException
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.nbt.CompoundTag
@@ -17,41 +18,35 @@ import net.minecraftforge.common.capabilities.Capability
 import net.minecraftforge.common.capabilities.CapabilityManager
 import net.minecraftforge.common.capabilities.CapabilityToken
 import net.minecraftforge.common.util.LazyOptional
-import net.minecraftforge.fml.loading.FMLEnvironment
 import net.minecraftforge.items.IItemHandler
 import net.minecraftforge.items.ItemStackHandler
 
 class AnalysisTableEntity(type: BlockEntityType<AnalysisTableEntity>, pos: BlockPos, state: BlockState) :
     BlockEntity(type, pos, state) {
-    private val inventoryLazy = LazyOptional.of {
-        object : ItemStackHandler(1) {
-            override fun onContentsChanged(slot: Int) {
-                super.onContentsChanged(slot)
-                setChanged()
-
-
-            }
-
-            override fun isItemValid(slot: Int, stack: ItemStack): Boolean {
-                return super.isItemValid(slot, stack) && (stack.item is EnchantedBookItem || stack.isEmpty)
+    private val inventory = object : ItemStackHandler(1) {
+        override fun onContentsChanged(slot: Int) {
+            super.onContentsChanged(slot)
+            setChanged()
+            if (level?.isClientSide == false) {
+                level!!.setBlockAndUpdate(pos, state.setValue(AnalysisTable.HAS_BOOK, !stacks[0].isEmpty))
             }
         }
-    }
 
-    fun setBook(book: ItemStack): Boolean {
-        return if (inventoryLazy.resolve().get().isItemValid(0, book)) {
-            inventoryLazy.resolve().get().setStackInSlot(0, book)
-            true
-        } else {
-            if (!FMLEnvironment.production) {
-                LOGGER.warn("non EnchantedBookItem tried to be inserted to analysis table!")
-                Thread.dumpStack()
-            }
-            false
+        override fun isItemValid(slot: Int, stack: ItemStack): Boolean {
+            return super.isItemValid(slot, stack) && (stack.item is EnchantedBookItem || stack.isEmpty)
         }
     }
+    private val inventoryLazy = LazyOptional.of { inventory }
 
-    fun getBook() = inventoryLazy.resolve().get().getStackInSlot(0)
+    var book: ItemStack
+        set(value) {
+            if (!inventory.isItemValid(0, value)) {
+                devException("Please don't put non-enchanted book item into the table, please :)")
+            } else {
+                inventory.setStackInSlot(0, value)
+            }
+        }
+        get() = inventory.getStackInSlot(0)
 
     companion object {
         val INVENTORY_CAP: Capability<IItemHandler> = CapabilityManager.get(object : CapabilityToken<IItemHandler>() {})
@@ -68,13 +63,23 @@ class AnalysisTableEntity(type: BlockEntityType<AnalysisTableEntity>, pos: Block
         inventoryLazy.invalidate()
     }
 
-    override fun getUpdateTag(): CompoundTag {
-        return getBook().serializeNBT()
+    override fun saveAdditional(tag: CompoundTag) {
+        super.saveAdditional(tag)
+        tag.put("book", book.serializeNBT())
     }
 
-    override fun onDataPacket(net: Connection, pkt: ClientboundBlockEntityDataPacket) {
-        val item = ItemStack.of(pkt.tag!!)
-        setBook(item)
+    override fun load(tag: CompoundTag) {
+        super.load(tag)
+        book = ItemStack.of(tag.getCompound("book"))
+    }
+
+    override fun getUpdateTag(): CompoundTag {
+        return book.serializeNBT()
+    }
+
+    override fun onDataPacket(connection: Connection, packet: ClientboundBlockEntityDataPacket) {
+        val item = ItemStack.of(packet.tag!!)
+        book = item
     }
 
     override fun getUpdatePacket(): Packet<ClientGamePacketListener>? {

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
@@ -54,7 +54,7 @@ class AnalysisTableEntity(type: BlockEntityType<AnalysisTableEntity>, pos: Block
     fun getBook() = inventoryLazy.resolve().get().getStackInSlot(0)
 
     companion object {
-        val INVENTORY_CAP = CapabilityManager.get(object : CapabilityToken<IItemHandler>() {})
+        val INVENTORY_CAP: Capability<IItemHandler> = CapabilityManager.get(object : CapabilityToken<IItemHandler>() {})
     }
 
     override fun <T : Any?> getCapability(cap: Capability<T>, side: Direction?): LazyOptional<T> {

--- a/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/blocks/entity/AnalysisTableEntity.kt
@@ -1,10 +1,83 @@
 package com.hkmod.soluna.common.blocks.entity
 
+import com.hkmod.soluna.Soluna.LOGGER
 import net.minecraft.core.BlockPos
+import net.minecraft.core.Direction
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.network.Connection
+import net.minecraft.network.protocol.Packet
+import net.minecraft.network.protocol.game.ClientGamePacketListener
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket
+import net.minecraft.world.item.EnchantedBookItem
+import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraft.world.level.block.state.BlockState
+import net.minecraftforge.common.capabilities.Capability
+import net.minecraftforge.common.capabilities.CapabilityManager
+import net.minecraftforge.common.capabilities.CapabilityToken
+import net.minecraftforge.common.util.LazyOptional
+import net.minecraftforge.fml.loading.FMLEnvironment
+import net.minecraftforge.items.IItemHandler
+import net.minecraftforge.items.ItemStackHandler
 
-class AnalysisTableEntity(type: BlockEntityType<AnalysisTableEntity>, pos: BlockPos, state: BlockState):
+class AnalysisTableEntity(type: BlockEntityType<AnalysisTableEntity>, pos: BlockPos, state: BlockState) :
     BlockEntity(type, pos, state) {
+    private val inventoryLazy = LazyOptional.of {
+        object : ItemStackHandler(1) {
+            override fun onContentsChanged(slot: Int) {
+                super.onContentsChanged(slot)
+                setChanged()
+
+
+            }
+
+            override fun isItemValid(slot: Int, stack: ItemStack): Boolean {
+                return super.isItemValid(slot, stack) && (stack.item is EnchantedBookItem || stack.isEmpty)
+            }
+        }
+    }
+
+    fun setBook(book: ItemStack): Boolean {
+        return if (inventoryLazy.resolve().get().isItemValid(0, book)) {
+            inventoryLazy.resolve().get().setStackInSlot(0, book)
+            true
+        } else {
+            if (!FMLEnvironment.production) {
+                LOGGER.warn("non EnchantedBookItem tried to be inserted to analysis table!")
+                Thread.dumpStack()
+            }
+            false
+        }
+    }
+
+    fun getBook() = inventoryLazy.resolve().get().getStackInSlot(0)
+
+    companion object {
+        val INVENTORY_CAP = CapabilityManager.get(object : CapabilityToken<IItemHandler>() {})
+    }
+
+    override fun <T : Any?> getCapability(cap: Capability<T>, side: Direction?): LazyOptional<T> {
+        if (cap == INVENTORY_CAP) return inventoryLazy.cast()
+
+        return super.getCapability(cap, side)
+    }
+
+    override fun invalidateCaps() {
+        super.invalidateCaps()
+        inventoryLazy.invalidate()
+    }
+
+    override fun getUpdateTag(): CompoundTag {
+        return getBook().serializeNBT()
+    }
+
+    override fun onDataPacket(net: Connection, pkt: ClientboundBlockEntityDataPacket) {
+        val item = ItemStack.of(pkt.tag!!)
+        setBook(item)
+    }
+
+    override fun getUpdatePacket(): Packet<ClientGamePacketListener>? {
+        return ClientboundBlockEntityDataPacket.create(this)
+    }
 }

--- a/src/main/kotlin/com/hkmod/soluna/common/items/SolunaItems.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/items/SolunaItems.kt
@@ -1,7 +1,10 @@
 package com.hkmod.soluna.common.items
 
 import com.hkmod.soluna.MODID
+import net.minecraft.world.item.CreativeModeTab
 import net.minecraft.world.item.Item
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import net.minecraftforge.eventbus.api.IEventBus
 import net.minecraftforge.registries.DeferredRegister
 import net.minecraftforge.registries.ForgeRegistries
@@ -10,4 +13,11 @@ object SolunaItems {
     private val ITEMS: DeferredRegister<Item> = DeferredRegister.create(ForgeRegistries.ITEMS, MODID)
 
     fun registerItems(bus: IEventBus) = ITEMS.register(bus)
+}
+
+object SolunaTab : CreativeModeTab(-1, MODID) {
+    override fun makeIcon(): ItemStack {
+        return ItemStack(Items.DIAMOND)
+    }
+
 }

--- a/src/main/kotlin/com/hkmod/soluna/common/util/DevUtil.kt
+++ b/src/main/kotlin/com/hkmod/soluna/common/util/DevUtil.kt
@@ -1,0 +1,12 @@
+package com.hkmod.soluna.common.util
+
+import com.hkmod.soluna.Soluna
+import net.minecraftforge.fml.loading.FMLEnvironment
+
+fun devException(message: String) {
+    if (FMLEnvironment.production) {
+        Soluna.LOGGER.error(message)
+    } else {
+        throw IllegalStateException(message)
+    }
+}

--- a/src/main/kotlin/com/hkmod/soluna/datagen/Main.kt
+++ b/src/main/kotlin/com/hkmod/soluna/datagen/Main.kt
@@ -1,0 +1,13 @@
+package com.hkmod.soluna.datagen
+
+import com.hkmod.soluna.datagen.languages.SolunaEN
+import com.hkmod.soluna.datagen.languages.SolunaKR
+import net.minecraftforge.data.event.GatherDataEvent
+
+fun datagen(event: GatherDataEvent) {
+    event.generator.run {
+        addProvider(event.includeServer(), SolunaRecipes(this))
+        addProvider(event.includeClient(), SolunaKR(this))
+        addProvider(event.includeClient(), SolunaEN(this))
+    }
+}

--- a/src/main/kotlin/com/hkmod/soluna/datagen/SolunaRecipes.kt
+++ b/src/main/kotlin/com/hkmod/soluna/datagen/SolunaRecipes.kt
@@ -1,0 +1,28 @@
+package com.hkmod.soluna.datagen
+
+import com.hkmod.soluna.common.blocks.SolunaBlocks
+import net.minecraft.data.DataGenerator
+import net.minecraft.data.recipes.FinishedRecipe
+import net.minecraft.data.recipes.RecipeProvider
+import net.minecraft.data.recipes.ShapedRecipeBuilder
+import net.minecraft.world.item.Items
+import net.minecraft.world.level.block.Blocks
+import java.util.function.Consumer
+
+class SolunaRecipes(generator: DataGenerator) : RecipeProvider(generator) {
+    override fun buildCraftingRecipes(finishedRecipeConsumer: Consumer<FinishedRecipe>) {
+        ShapedRecipeBuilder.shaped(SolunaBlocks.ANALYSIS_TABLE.asItem()).run {
+            define('l', Blocks.LECTERN.asItem())
+            define('e', Items.LEATHER)
+            define('i', Items.INK_SAC)
+            define('f', Items.FEATHER)
+
+            pattern("e  ")
+            pattern("li ")
+            pattern("f  ")
+
+            unlockedBy("has_lectern", has(Blocks.LECTERN.asItem()))
+            unlockedBy("has_enchanted_book", has(Items.ENCHANTED_BOOK))
+        }.save(finishedRecipeConsumer)
+    }
+}

--- a/src/main/kotlin/com/hkmod/soluna/datagen/languages/SolunaEN.kt
+++ b/src/main/kotlin/com/hkmod/soluna/datagen/languages/SolunaEN.kt
@@ -1,0 +1,15 @@
+package com.hkmod.soluna.datagen.languages
+
+import com.hkmod.soluna.MODID
+import com.hkmod.soluna.common.blocks.SolunaBlocks
+import net.minecraft.data.DataGenerator
+import net.minecraftforge.common.data.LanguageProvider
+
+class SolunaEN(gen: DataGenerator) : LanguageProvider(gen, MODID, "en_us") {
+    override fun addTranslations() {
+        add(SolunaBlocks.ANALYSIS_TABLE, "Analysis Table")
+        // TODO Add Key category translation
+        add("itemGroup.soluna", "Soluna")
+        add("key.categories.soluna", "Soluna")
+    }
+}

--- a/src/main/kotlin/com/hkmod/soluna/datagen/languages/SolunaKR.kt
+++ b/src/main/kotlin/com/hkmod/soluna/datagen/languages/SolunaKR.kt
@@ -1,0 +1,15 @@
+package com.hkmod.soluna.datagen.languages
+
+import com.hkmod.soluna.MODID
+import com.hkmod.soluna.common.blocks.SolunaBlocks
+import net.minecraft.data.DataGenerator
+import net.minecraftforge.common.data.LanguageProvider
+
+class SolunaKR(gen: DataGenerator) : LanguageProvider(gen, MODID, "ko_kr") {
+    override fun addTranslations() {
+        add(SolunaBlocks.ANALYSIS_TABLE, "분석 탁자")
+        // TODO 키 카테고리 번역 추가하기
+        add("itemGroup.soluna", "Soluna")
+        add("key.categories.soluna", "Soluna")
+    }
+}

--- a/src/main/resources/assets/soluna/blockstates/analysis_table.json
+++ b/src/main/resources/assets/soluna/blockstates/analysis_table.json
@@ -1,7 +1,19 @@
 {
   "variants": {
-    "": {
+    "facing=east": {
+      "model": "soluna:block/analysis_table",
+      "y": 90
+    },
+    "facing=north": {
       "model": "soluna:block/analysis_table"
+    },
+    "facing=south": {
+      "model": "soluna:block/analysis_table",
+      "y": 180
+    },
+    "facing=west": {
+      "model": "soluna:block/analysis_table",
+      "y": 270
     }
   }
 }

--- a/src/main/resources/assets/soluna/lang/en_us.json
+++ b/src/main/resources/assets/soluna/lang/en_us.json
@@ -1,4 +1,0 @@
-{
-    "itemGroup.soluna": "Soluna",
-    "key.categories.soluna": "Soluna"
-}

--- a/src/main/resources/assets/soluna/lang/ko_kr.json
+++ b/src/main/resources/assets/soluna/lang/ko_kr.json
@@ -1,4 +1,0 @@
-{
-    "itemGroup.soluna": "Soluna",
-    "key.categories.soluna": "Soluna"
-}

--- a/src/main/resources/assets/soluna/models/block/analysis_table.json
+++ b/src/main/resources/assets/soluna/models/block/analysis_table.json
@@ -3,7 +3,6 @@
 	"parent": "block/block",
 	"textures": {
 		"4": "soluna:block/analysis_table/sheet",
-		"12": "entity/enchanting_table_book",
 		"bottom": "soluna:block/analysis_table/topbar",
 		"front": "block/lectern_front",
 		"particle": "block/lectern_sides",
@@ -12,20 +11,20 @@
 	},
 	"elements": [
 		{
-			"name": "base0",
+			"name": "foundation",
 			"from": [0, 0, 0],
 			"to": [16, 2, 16],
 			"faces": {
-				"north": {"uv": [8, 0, 16, 1], "texture": "#bottom", "cullface": "north"},
-				"east": {"uv": [8, 1, 16, 2], "texture": "#bottom", "cullface": "east"},
-				"south": {"uv": [8, 2, 16, 3], "texture": "#bottom", "cullface": "south"},
-				"west": {"uv": [8, 3, 16, 4], "texture": "#bottom", "cullface": "west"},
-				"up": {"uv": [8, 8, 0, 0], "texture": "#bottom"},
-				"down": {"uv": [8, 8, 0, 16], "texture": "#bottom", "cullface": "down"}
+				"north": {"uv": [0, 6, 16, 8], "texture": "#bottom", "cullface": "north"},
+				"east": {"uv": [0, 6, 16, 8], "texture": "#bottom", "cullface": "east"},
+				"south": {"uv": [0, 6, 16, 8], "texture": "#bottom", "cullface": "south"},
+				"west": {"uv": [0, 6, 16, 8], "texture": "#bottom", "cullface": "west"},
+				"up": {"uv": [16, 16, 0, 0], "texture": "#bottom"},
+				"down": {"uv": [16, 0, 0, 16], "texture": "#bottom", "cullface": "down"}
 			}
 		},
 		{
-			"name": "base1",
+			"name": "pillar",
 			"from": [4, 2, 4],
 			"to": [12, 15, 12],
 			"faces": {
@@ -36,17 +35,17 @@
 			}
 		},
 		{
-			"name": "base2",
+			"name": "base",
 			"from": [0.0125, 12, 3],
 			"to": [15.9875, 16, 16],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 8, 8]},
 			"faces": {
-				"north": {"uv": [0, 0, 16, 4], "texture": "#sides"},
-				"east": {"uv": [0, 4, 13, 8], "texture": "#sides"},
-				"south": {"uv": [0, 4, 16, 8], "texture": "#sides"},
-				"west": {"uv": [0, 4, 13, 8], "texture": "#sides"},
-				"up": {"uv": [0, 1, 16, 14], "rotation": 180, "texture": "#top"},
-				"down": {"uv": [0, 0, 16, 13], "texture": "#bottom"}
+				"north": {"uv": [0, 14, 16, 16], "texture": "#sides"},
+				"east": {"uv": [0, 6, 16, 8], "texture": "#sides", "cullface": "south"},
+				"south": {"uv": [0, 6, 16, 8], "texture": "#sides"},
+				"west": {"uv": [0, 6, 16, 8], "texture": "#sides", "cullface": "west"},
+				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#top"},
+				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
 			}
 		},
 		{
@@ -64,87 +63,17 @@
 			}
 		},
 		{
-			"name": "topbar",
+			"name": "bar",
 			"from": [0, 12.75, 0.93],
 			"to": [16, 13.75, 1.93],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 11.45, -0.67]},
 			"faces": {
-				"north": {"uv": [0, 12, 16, 16], "texture": "#bottom"},
-				"east": {"uv": [0, 8, 4, 12], "texture": "#bottom"},
-				"south": {"uv": [0, 4, 16, 8], "texture": "#bottom"},
-				"west": {"uv": [0, 0, 4, 4], "texture": "#bottom"},
-				"up": {"uv": [0, 0, 16, 4], "texture": "#bottom"},
-				"down": {"uv": [0, 8, 16, 12], "texture": "#bottom"}
-			}
-		},
-		{
-			"name": "book_cover_left",
-			"from": [8.3, 16.33702, 1.98883],
-			"to": [13.8, 16.33702, 9.98883],
-			"rotation": {"angle": -22.5, "axis": "x", "origin": [11.675, 16.33702, 5.18883]},
-			"faces": {
-				"north": {"uv": [0, 0, 1, 0], "rotation": 180, "texture": "#missing"},
-				"east": {"uv": [0, 0, 1, 0], "rotation": 180, "texture": "#missing"},
-				"south": {"uv": [0, 0, 1, 0], "rotation": 180, "texture": "#missing"},
-				"west": {"uv": [0, 0, 1, 0], "rotation": 180, "texture": "#missing"},
-				"up": {"uv": [0, 0, 1.75, 5], "rotation": 180, "texture": "#12"},
-				"down": {"uv": [1.75, 0, 3, 5], "texture": "#12"}
-			}
-		},
-		{
-			"name": "book_cover_right",
-			"from": [2.3, 16.33702, 1.98883],
-			"to": [8.3, 16.33702, 9.98883],
-			"rotation": {"angle": -22.5, "axis": "x", "origin": [11.675, 16.33702, 5.18883]},
-			"faces": {
-				"north": {"uv": [0, 0, 1, 0], "rotation": 180, "texture": "#missing"},
-				"east": {"uv": [0, 0, 1, 0], "rotation": 180, "texture": "#missing"},
-				"south": {"uv": [0, 0, 1, 0], "rotation": 180, "texture": "#missing"},
-				"west": {"uv": [0, 0, 1, 0], "rotation": 180, "texture": "#missing"},
-				"up": {"uv": [5.5, 0, 3, 5], "texture": "#12"},
-				"down": {"uv": [5.5, 0, 7, 5], "texture": "#12"}
-			}
-		},
-		{
-			"name": "book_contents_right",
-			"from": [2.9, 16.8, 1.6],
-			"to": [7.6, 17.8, 8],
-			"rotation": {"angle": -22.5, "axis": "x", "origin": [8.5, 19.5, 5.5]},
-			"faces": {
-				"north": {"uv": [6.25, 5, 8.5, 5.5], "rotation": 180, "texture": "#12"},
-				"east": {"uv": [6.25, 5, 8.5, 5.5], "rotation": 180, "texture": "#12"},
-				"south": {"uv": [6.25, 5, 8.5, 5.5], "rotation": 180, "texture": "#12"},
-				"west": {"uv": [6.25, 5, 8.5, 5.5], "rotation": 180, "texture": "#12"},
-				"up": {"uv": [0.25, 5.5, 1.5, 9.5], "rotation": 180, "texture": "#12"},
-				"down": {"uv": [0.25, 5.5, 1.5, 9.5], "rotation": 180, "texture": "#12"}
-			}
-		},
-		{
-			"name": "book_contents_left",
-			"from": [8.3, 16.8, 1.6],
-			"to": [13, 17.8, 8],
-			"rotation": {"angle": -22.5, "axis": "x", "origin": [8.5, 19.5, 5.5]},
-			"faces": {
-				"north": {"uv": [6.25, 5, 8.5, 5.5], "rotation": 180, "texture": "#12"},
-				"east": {"uv": [6.25, 5, 8.5, 5.5], "rotation": 180, "texture": "#12"},
-				"south": {"uv": [6.25, 5, 8.5, 5.5], "rotation": 180, "texture": "#12"},
-				"west": {"uv": [6.25, 5, 8.5, 5.5], "rotation": 180, "texture": "#12"},
-				"up": {"uv": [1.75, 5.5, 3, 9.5], "rotation": 180, "texture": "#12"},
-				"down": {"uv": [0.25, 5.5, 1.5, 9.5], "rotation": 180, "texture": "#12"}
-			}
-		},
-		{
-			"name": "book_contents_middle",
-			"from": [7.6, 14.01421, 2.48579],
-			"to": [8.3, 14.81421, 8.88579],
-			"rotation": {"angle": -22.5, "axis": "x", "origin": [10.5, 15.91421, -0.91421]},
-			"faces": {
-				"north": {"uv": [1.5, 5.5, 1.75, 9.5], "rotation": 180, "texture": "#12"},
-				"east": {"uv": [1.5, 5.5, 1.75, 9.5], "rotation": 180, "texture": "#12"},
-				"south": {"uv": [1.5, 5.5, 1.75, 9.5], "rotation": 180, "texture": "#12"},
-				"west": {"uv": [1.5, 5.5, 1.75, 9.5], "rotation": 180, "texture": "#12"},
-				"up": {"uv": [1.5, 5.5, 1.75, 9.5], "rotation": 180, "texture": "#12"},
-				"down": {"uv": [1.5, 5.5, 1.75, 9.5], "rotation": 180, "texture": "#12"}
+				"north": {"uv": [0, 14, 16, 16], "texture": "#bottom"},
+				"east": {"uv": [14, 6, 16, 8], "texture": "#bottom"},
+				"south": {"uv": [0, 6, 16, 8], "texture": "#bottom"},
+				"west": {"uv": [0, 6, 2, 8], "texture": "#bottom"},
+				"up": {"uv": [0, 6, 16, 8], "rotation": 180, "texture": "#bottom"},
+				"down": {"uv": [0, 14, 16, 16], "texture": "#bottom"}
 			}
 		}
 	],
@@ -153,19 +82,5 @@
 			"rotation": [0, 135, 0],
 			"scale": [0.4, 0.4, 0.4]
 		}
-	},
-	"groups": [
-		0,
-		1,
-		2,
-		3,
-		4,
-		{
-			"name": "book",
-			"origin": [9.5, 18, 4.5],
-			"color": 0,
-			"children": [5, 6, 7, 8, 9]
-		},
-		10
-	]
+	}
 }


### PR DESCRIPTION
이번 PR에서는 지금까지 까먹고 진행못했던 분석 탁자를 추가할꺼야. 조합법은 다음과 같아.
![image](https://user-images.githubusercontent.com/41675181/192591865-7517ce76-8e98-4d9a-95bb-38d65c2dbd74.png)
인첸트된 책, 그리고 독서대를 휙득하였을 경우 분석 탁자 조합법이 사진처럼 인벤토리 조합법 목록에 추가되.
그리고 현재까지 구현된 기능들은 전부 이 영상에 나와있어:
https://drive.google.com/file/d/1jcCyT0x6laP9vcttE_MQjzHQQj9-p6Qe/view?usp=sharing

~~IItemHandler 캐패빌리티를 사용했기 때문에 아이템 전송 기능이 있는 *모든* 것과 호환될꺼야.~~ - 더 이상 캐패빌리티를 사용하지 않기 때문에 영상에서와 다르게 깔때기 또는 공급기를 사용할 수 없어.
조합법과 언어 파일들을 작성하는 과정에서 데이터 생성기를 설정 및 사용했어. 그런데 데이터 생성기가 만들어낸 언어 파일이랑, 우리가 수동으로 적은 언어 파일을 동시에 사용하는 것이 안되서 전부다 데이터 생성기로 만들어내도록 전환했어.